### PR TITLE
refactor(src/user/profile.js): updateUIDMapping to have less parameters

### DIFF
--- a/src/user/profile.js
+++ b/src/user/profile.js
@@ -306,15 +306,15 @@ module.exports = function (User) {
 		const newUserslug = slugify(newUsername);
 		const now = Date.now();
 		await Promise.all([
-			updateUidMapping('username', uid, newUsername, userData.username),
-			updateUidMapping('userslug', uid, newUserslug, userData.userslug),
+			updateUidMapping({field: 'username', uid: uid, value: newUsername, oldValue: userData.username}),
+			updateUidMapping({field: 'userslug', uid: uid, value: newUserslug, oldValue: userData.userslug}),
 			db.sortedSetAdd(`user:${uid}:usernames`, now, `${newUsername}:${now}:${callerUid}`),
 		]);
 		await db.sortedSetRemove('username:sorted', `${userData.username.toLowerCase()}:${uid}`);
 		await db.sortedSetAdd('username:sorted', 0, `${newUsername.toLowerCase()}:${uid}`);
 	}
 
-	async function updateUidMapping(field, uid, value, oldValue) {
+	async function updateUidMapping({ field, uid, value, oldValue }) {
 		if (value === oldValue) {
 			return;
 		}
@@ -327,7 +327,7 @@ module.exports = function (User) {
 
 	async function updateFullname(uid, newFullname) {
 		const fullname = await db.getObjectField(`user:${uid}`, 'fullname');
-		await updateUidMapping('fullname', uid, newFullname, fullname);
+		await updateUidMapping({field: 'fullname', uid: uid, value: newFullname, oldValue: fullname});
 		if (newFullname !== fullname) {
 			if (fullname) {
 				await db.sortedSetRemove('fullname:sorted', `${fullname.toLowerCase()}:${uid}`);


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Please provide a link to the associated GitHub issue:**

[**Link to the associated GitHub issue:**](https://github.com/CMU-313/NodeBB/issues/7)

**Full path to the refactored file:**
src/user/profile.js

**What do you think this file does?**
This file handles the functionality regarding your user profile. Examples of some functionality are: updating your email, updating your username, etc... 

**What is the scope of your refactoring within that file?**
I specifically made changes to the `updateUidMapping` function to pass a single object instead of having four parameters. I made changes to the function definition, and updated the calls to the function in the three other places it was called within the file. 

**Which Qlty‑reported issue did you address?**
Function with many parameters (count = 4): updateUidMapping

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
Having multiple parameters can cause readability issues. Especially when making calls to a function, if it has far too many parameters, it can be difficult to keep track of which variable belongs where and in what order when making the call. 

**What changes did you make to resolve the issue?**
I changed the function definition to have a single object passed in instead of multiple parameters. This way, the caller is forced to pass the arguments in key:value format. Ex: `field:'username'` clearly indicates that the field is username, rather than simply passing in `'username'` previously. 

**How do your changes improve adaptability? Did you consider alternatives?**
The code is more readable. Since we have to pass the arguments in as an object, we must do it in key:value pair format, which forces the reader to look at exactly what each variable they are passing in is meant to be within the function we are passing it into. 

## 3. Validation

**How did you trigger the refactored code path from the UI?**
Assuming you have an account, I clicked on my profile and changed my username. Once I made the change, the print statement was printed twice (since the `updateUsername` function calls `updateUidMapping` twice). 

**Attach a screenshot of the logs and UI demonstrating the trigger.**

<img width="1312" height="912" alt="Screenshot 2025-08-30 at 3 38 07 PM" src="https://github.com/user-attachments/assets/08d96557-0a15-479c-869e-16aeceab5125" />

<img width="1607" height="1009" alt="Screenshot 2025-08-30 at 3 58 40 PM" src="https://github.com/user-attachments/assets/d6414bfa-1609-4ca5-8c44-73e5d7b640b5" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**

Before: 
<img width="603" height="223" alt="Screenshot 2025-08-30 at 3 59 37 PM" src="https://github.com/user-attachments/assets/38f8943a-308d-468c-9d90-8890f677f2c6" />

After:
<img width="775" height="205" alt="Screenshot 2025-08-30 at 4 00 08 PM" src="https://github.com/user-attachments/assets/285b7de6-9349-45df-ae22-59c1b3db8db8" />

