### PR TITLE
Fix getNotificationsFromSet to take in less parameters

### DIFF
--- a/src/user/notifications.js
+++ b/src/user/notifications.js
@@ -20,11 +20,11 @@ UserNotifications.get = async function (uid) {
 		return { read: [], unread: [] };
 	}
 
-	let unread = await getNotificationsFromSet(`uid:${uid}:notifications:unread`, uid, 0, 49);
+	let unread = await getNotificationsFromSet(`uid:${uid}:notifications:unread`, uid, {start : 0, stop : 49});
 	unread = unread.filter(Boolean);
 	let read = [];
 	if (unread.length < 50) {
-		read = await getNotificationsFromSet(`uid:${uid}:notifications:read`, uid, 0, 49 - unread.length);
+		read = await getNotificationsFromSet(`uid:${uid}:notifications:read`, uid, {start : 0, stop : 49 - unread.length});
 	}
 
 	return await plugins.hooks.fire('filter:user.notifications.get', {
@@ -91,8 +91,8 @@ async function deleteUserNids(nids, uid) {
 	], nids);
 }
 
-async function getNotificationsFromSet(set, uid, start, stop) {
-	const nids = await db.getSortedSetRevRange(set, start, stop);
+async function getNotificationsFromSet(set, uid, startStopHolder) {
+	const nids = await db.getSortedSetRevRange(set, startStopHolder.start, startStopHolder.stop);
 	return await UserNotifications.getNotifications(nids, uid);
 }
 


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue:** [Issue](https://github.com/CMU-313/NodeBB/issues/4)

**Full path to the refactored file:**  src/user/notifications.js

**What do you think this file does?**
This file seems to get all the notifications to populate the notification tab which you can access by clicking the bell icon. It also provides other functions which pertain to sending specific types of notifications as well as getting the unread notifications.

**What is the scope of your refactoring within that file?**
I changed getNotificationsFromSet andUserNotifications.get

**Which Qlty‑reported issue did you address?**
Function with many parameters (count = 4) in getNotificationsFromSet()

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability? **
Now for future additions to this function, you can now add to this object instead of adding a new parameter.

**What changes did you make to resolve the issue?**
I created an object to hold both the start and stop time since these two variables are related, so I found it appropriate to group them into a start/stop holder object.

**How do your changes improve adaptability? Did you consider alternatives?**
I considered creating a javascript class, but felt that it was not necessary. I thought that this function would not need new additions in the future and creating a new class would add a lot of code. Creating a new class might make it more difficult to understand in the future. Now in any future cases you can just quickly add to this object I made.

## 3. Validation

On the home page, simply click the notification button (the bell button) and this will cause the log. 

<img width="963" height="197" alt="notifications proof" src="https://github.com/user-attachments/assets/2f94bb63-57d9-49e8-a539-6cac0be57ee8" />

**The highlight represents what to click**

<img width="1906" height="1101" alt="what to click" src="https://github.com/user-attachments/assets/9d53a37e-ee72-47f2-ad54-290fba74b7ef" />

**qlty smells**
<img width="865" height="97" alt="no qlty issues" src="https://github.com/user-attachments/assets/5cb4af0a-fc25-444b-8a20-c96bd9aaa30c" />
