### PR TITLE
Created an unanswered page and unanswered icon 

### DIFF
--- a/public/openapi/read.yaml
+++ b/public/openapi/read.yaml
@@ -226,6 +226,8 @@ paths:
     $ref: 'read/recent/posts/term.yaml'
   /api/unread:
     $ref: 'read/unread.yaml'
+  /api/unanswered:
+    $ref: 'read/unanswered.yaml'
   /api/unread/total:
     $ref: 'read/unread/total.yaml'
   "/api/topic/teaser/{topic_id}":

--- a/public/openapi/read/unanswered.yaml
+++ b/public/openapi/read/unanswered.yaml
@@ -1,0 +1,25 @@
+get:
+  tags:
+    - topics
+  summary: Unanswered topics
+  description: Returns a list of unanswered topics for the current user (read-only)
+  responses:
+    "200":
+      description: An object containing a list of topics and common page props
+      content:
+        application/json:
+          schema:
+            allOf:
+              - type: object
+                properties:
+                  title:
+                    type: string
+                  pageCount:
+                    type: number
+                  topics:
+                    type: array
+                    items:
+                      $ref: ../components/schemas/TopicObject.yaml#/TopicObjectSlim
+              - $ref: ../components/schemas/Pagination.yaml#/Pagination
+              - $ref: ../components/schemas/Breadcrumbs.yaml#/Breadcrumbs
+              - $ref: ../components/schemas/CommonProps.yaml#/CommonProps

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -43,6 +43,13 @@ Controllers.composer = require('./composer');
 
 Controllers.write = require('./write');
 
+// Unanswered page controller
+try {
+	Controllers.unanswered = require('./unanswered');
+} catch (e) {
+	// If the file isn't present or failed to load, ignore — dev/test environments may differ
+}
+
 Controllers.reset = async function (req, res) {
 	if (meta.config['password:disableEdit']) {
 		return helpers.notAllowed(req, res);

--- a/src/controllers/unanswered.js
+++ b/src/controllers/unanswered.js
@@ -13,10 +13,10 @@ module.exports = async function (req, res) {
 	const data = {
 		title: 'Unanswered',
 		breadcrumbs: helpers.buildBreadcrumbs([
-		{ text: '[[pages:unanswered]]' },
+			{ text: '[[pages:unanswered]]' },
 		]),
-	widgets: res.locals.widgets || {},
-	topics: [],
+		widgets: res.locals.widgets || {},
+		topics: [],
 	};
 
 	// pagination and pageCount so API responses match documented schema

--- a/src/controllers/unanswered.js
+++ b/src/controllers/unanswered.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const meta = require('../meta');
+const helpers = require('./helpers');
+const pagination = require('../pagination');
+
+module.exports = async function (req, res) {
+	const page = parseInt(req.query.page, 10) || 1;
+	const metaConfigBool = (meta.config && meta.config.topicsPerPage);
+	const resLocals = (res.locals && res.locals.user && res.locals.user.topicsPerPage);
+	const topicsPerPage = resLocals || metaConfigBool || 10;
+
+	const data = {
+		title: 'Unanswered',
+		breadcrumbs: helpers.buildBreadcrumbs([
+		{ text: '[[pages:unanswered]]' },
+		]),
+	widgets: res.locals.widgets || {},
+	topics: [],
+	};
+
+	// pagination and pageCount so API responses match documented schema
+	data.pageCount = Math.max(1, Math.ceil((data.topicCount || 0) / topicsPerPage));
+	data.pagination = pagination.create(page, data.pageCount, req.query);
+
+	res.render('unanswered', data);
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -39,6 +39,9 @@ _mounts.main = (app, middleware, controllers) => {
 	setupPageRoute(app, '/reset/:code?', [middleware.delayLoading], controllers.reset);
 	setupPageRoute(app, '/tos', [], controllers.termsOfUse);
 
+	// Unanswered page: admin only
+	setupPageRoute(app, '/unanswered', [middleware.ensureLoggedIn, middleware.admin.checkPrivileges], controllers.unanswered);
+
 	setupPageRoute(app, '/email/unsubscribe/:token', [], controllers.accounts.settings.unsubscribe);
 	app.post('/email/unsubscribe/:token', controllers.accounts.settings.unsubscribePost);
 

--- a/src/views/unanswered.tpl
+++ b/src/views/unanswered.tpl
@@ -1,0 +1,16 @@
+{{{ if widgets.header.length }}}
+    <div class="category">
+        <div id="category-no-topics" class="alert alert-info {{{ if topics.length }}}hidden{{{ end }}}">Load More Unanswered Questions</div>
+
+        <button id="load-more-btn" class="btn btn-primary hide">Load More</button>
+        
+        {{{ if config.usePagination }}}
+        {{{ end }}}
+    </div>
+</div>
+
+<div data-widget-area="sidebar" class="col-lg-3 col-sm-12 {{{ if !widgets.sidebar.length }}}hidden{{{ end }}}">
+    {{{ each widgets.sidebar }}}
+    {{widgets.sidebar.html}}
+    {{{ end }}}
+</div>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/sidebar/logged-in-menu.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/sidebar/logged-in-menu.tpl
@@ -21,3 +21,11 @@
 <li component="sidebar/drafts" class="nav-item mx-2 drafts dropstart" title="[[global:header.drafts]]" role="menuitem">
 <!-- IMPORT partials/sidebar/drafts.tpl -->
 </li>
+
+{{{ if isAdmin }}}
+<li class="nav-item mx-2 unanswered dropstart" title="Unanswered" role="menuitem">
+	<a href="#" onclick="console.log('Unanswered click'); return false;" class="nav-link d-flex gap-2 align-items-center text-truncate" role="button" aria-label="Unanswered">
+		<span><i class="fa fa-question-circle fa-fw"></i></span>
+	</a>
+</li>
+{{{ end }}}


### PR DESCRIPTION
### Reason For This Pull Request

This is the first step to completing this issue: https://github.com/CMU-313/nodebb-fall-2025-yonko/issues/14
This issue is to allow a admin/professor to see questions which have not been answered so this is the start of the UI change while we are blocked on the back end

### In This Change

I added a new icon only visible to admins:

**Icon For Admins**
<img width="1908" height="1080" alt="image" src="https://github.com/user-attachments/assets/e96058e0-4d04-4eff-880f-9f196ef3399f" />

**Logging on Click**
<img width="733" height="242" alt="Screenshot 2025-09-20 160108" src="https://github.com/user-attachments/assets/eabbe235-59d1-4bb6-bc7c-e5ecc2292c1c" />

**View for Non-Admins**
<img width="1897" height="688" alt="image" src="https://github.com/user-attachments/assets/d455b8d1-b869-424b-9993-128d9aadcdb6" />

**Not Logged In**
<img width="1912" height="867" alt="image" src="https://github.com/user-attachments/assets/5358e4b6-cee6-4782-892c-eb7bc543146e" />



