### PR TITLE
Added a new tab to sort by unanswered to allow users to see unanswered posts

### DIFF
--- a/public/src/modules/sort.js
+++ b/public/src/modules/sort.js
@@ -15,6 +15,15 @@ define('sort', ['components'], function (components) {
 			.off('click', '[component="thread/sort"] a[data-sort]')
 			.on('click', '[component="thread/sort"] a[data-sort]', function () {
 				const newSetting = $(this).attr('data-sort');
+				// If the new 'No Replies' sort option is selected, keep this front-end-only
+				// and just log the action to the console as requested. Real filtering or
+				// server-side changes are out of scope for this change.
+				if (newSetting === 'no_replies') {
+					console.log('No Replies selected');
+					// Close dropdown if applicable and prevent navigation
+					$(this).closest('.dropdown-menu').prev('[data-bs-toggle="dropdown"]').dropdown && $(this).closest('.dropdown-menu').prev('[data-bs-toggle="dropdown"]').dropdown('hide');
+					return false;
+				}
 				const urlParams = utils.params();
 				urlParams.sort = newSetting;
 				const qs = $.param(urlParams);

--- a/src/views/partials/category/sort.tpl
+++ b/src/views/partials/category/sort.tpl
@@ -11,6 +11,13 @@
 				<i class="flex-shrink-0 fa fa-fw text-secondary"></i>
 			</a>
 		</li>
+			<li>
+				<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" href="#" data-sort="no_replies" role="menuitem">
+					<span class="flex-grow-1">No Replies</span>
+					<i class="flex-shrink-0 fa fa-fw text-secondary"></i>
+				</a>
+			</li>
+
 		<li>
 			<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" href="#" data-sort="recently_created" role="menuitem">
 				<span class="flex-grow-1">[[topic:recently-created]]</span>


### PR DESCRIPTION
**Reason For This Pull Request**
This is the first step to completing this issue: https://github.com/CMU-313/nodebb-fall-2025-yonko/issues/14
This issue is to allow someone to see questions which have not been answered so this is the start of the UI change while we are blocked on the back end

**In This Change**
Added a new dropdown menu with logging that when backend is done will allow sorting for unanswered 

<img width="733" height="700" alt="image" src="https://github.com/user-attachments/assets/0fa7680e-b11c-4fc9-b732-3641efe81337" />
