### PR TITLE
Endpoints: request/resolve follow-up complete along with testing

### DIFF
--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -150,6 +150,10 @@ paths:
     $ref: 'write/topics/tid/pin.yaml'
   /topics/{tid}/follow:
     $ref: 'write/topics/tid/follow.yaml'
+  /topics/{tid}/followup/request:
+    $ref: 'write/topics/tid/followup-request.yaml'
+  /topics/{tid}/followup/resolve:
+    $ref: 'write/topics/tid/followup-resolve.yaml'
   /topics/{tid}/ignore:
     $ref: 'write/topics/tid/ignore.yaml'
   /topics/{tid}/tags:

--- a/public/openapi/write/topics/tid/followup-request.yaml
+++ b/public/openapi/write/topics/tid/followup-request.yaml
@@ -1,0 +1,39 @@
+post:
+  tags:
+    - topics
+  summary: Request a followup for a topic
+  parameters:
+    - in: path
+      name: tid
+      required: true
+      schema:
+        type: integer
+      example: 1
+  responses:
+    '200':
+      description: Followup requested
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  followup:
+                    type: object
+                    properties:
+                      pending:
+                        type: boolean
+                      requestedBy:
+                        type: integer
+                      lastPingAt:
+                        type: integer
+    '403':
+      description: Forbidden (no privilege)
+    '404':
+      description: Topic not found
+    '429':
+      description: Rate limit / cooldown

--- a/public/openapi/write/topics/tid/followup-resolve.yaml
+++ b/public/openapi/write/topics/tid/followup-resolve.yaml
@@ -1,0 +1,39 @@
+post:
+  tags:
+    - topics
+  summary: Resolve a followup on a topic
+  parameters:
+    - in: path
+      name: tid
+      required: true
+      schema:
+        type: integer
+      example: 1
+  responses:
+    '200':
+      description: Followup resolved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  followup:
+                    type: object
+                    properties:
+                      pending:
+                        type: boolean
+                      requestedBy:
+                        type: integer
+                      lastPingAt:
+                        type: integer
+    '403':
+      description: Forbidden (no privilege)
+    '404':
+      description: Topic not found
+    '429':
+      description: Rate limit / cooldown

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -220,3 +220,14 @@ Topics.move = async (req, res) => {
 
 	helpers.formatApiResponse(200, res);
 };
+
+// Followup controllers
+Topics.requestFollowup = async (req, res) => {
+	const payload = await api.topics.requestFollowup(req, { tid: req.params.tid });
+	helpers.formatApiResponse(200, res, payload);
+};
+
+Topics.resolveFollowup = async (req, res) => {
+	const payload = await api.topics.resolveFollowup(req, { tid: req.params.tid });
+	helpers.formatApiResponse(200, res, payload);
+};

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -51,5 +51,9 @@ module.exports = function () {
 
 	setupApiRoute(router, 'put', '/:tid/move', [...middlewares, middleware.assert.topic], controllers.write.topics.move);
 
+	// Followup endpoints
+	setupApiRoute(router, 'post', '/:tid/followup/request', [...middlewares, middleware.assert.topic], controllers.write.topics.requestFollowup);
+	setupApiRoute(router, 'post', '/:tid/followup/resolve', [...middlewares, middleware.assert.topic], controllers.write.topics.resolveFollowup);
+
 	return router;
 };

--- a/test/topics-followup-api.test.js
+++ b/test/topics-followup-api.test.js
@@ -1,0 +1,169 @@
+const assert = require('assert');
+
+// This test file is standalone and stubs modules required by the API.
+// It assumes your test runner is mocha (node --test or mocha).
+
+const topicsApi = require('../src/api/topics');
+const topics = require('../src/topics');
+const followupGuard = require('../src/topics/followup-guard');
+const events = require('../src/events');
+const socketHelpers = require('../src/socket.io/helpers');
+
+describe('topicsAPI followup endpoints', () => {
+	let emitted;
+	let logged;
+	let _origTopicsExists;
+	let _origTopicsGetFollowup;
+
+	beforeEach(() => {
+		// capture emissions/logs
+		emitted = [];
+		logged = [];
+
+		// Stub socket emit helper
+		socketHelpers.emitToUids = (event, data, uids) => {
+			emitted.push({ event, data, uids });
+		};
+
+		// Stub events.log
+		events.log = async (obj) => {
+			logged.push(obj);
+		};
+
+		// Save original exists to restore after test
+		_origTopicsExists = topics.exists;
+		// Save original getFollowup to restore after test
+		_origTopicsGetFollowup = topics.getFollowup;
+
+		// Default topic persistence stubs
+		// Keep behavior compatible with Topics.exists: return a boolean for single
+		// tid, or an array of booleans for an array of tids.
+		topics.exists = async (tid) => {
+			if (Array.isArray(tid)) {
+				return tid.map(() => true);
+			}
+			return true;
+		};
+		// prefer setFollowup if present, otherwise updateTopicField/update
+		topics._storedFollowups = {};
+		topics.setFollowup = async (tid, followup) => {
+			topics._storedFollowups[tid] = followup;
+		};
+		// Make getFollowup return the stored followup (or defaults) so API's read-path works in tests
+		topics.getFollowup = async (tid) => {
+			if (topics._storedFollowups.hasOwnProperty(tid)) return topics._storedFollowups[tid];
+			return { pending: false, requestedBy: 0, lastPingAt: 0 };
+		};
+		topics.updateTopicField = async (tid, field, val) => {
+			if (field === 'followup') topics._storedFollowups[tid] = val;
+		};
+		topics.update = async (tid, data) => {
+			if (data && data.followup) topics._storedFollowups[tid] = data.followup;
+		};
+
+		// Default guard: allow
+		followupGuard.assertCanRequestFollowup = async () => {};
+		followupGuard.assertCooldownAndMark = async () => {};
+		followupGuard.assertCanResolveFollowup = async () => {};
+	});
+
+	afterEach(() => {
+		// Restore original exists implementation so other tests aren't affected
+		topics.exists = _origTopicsExists;
+		// Restore original getFollowup implementation
+		topics.getFollowup = _origTopicsGetFollowup;
+	});
+
+	it('requestFollowup: sets pending=true, requestedBy and lastPingAt; emits and logs', async () => {
+		const caller = { uid: 123, ip: '1.2.3.4' };
+		const tid = 42;
+
+		const res = await topicsApi.requestFollowup(caller, { tid });
+		const f = res.followup;
+
+		assert.strictEqual(f.pending, true);
+		assert.strictEqual(f.requestedBy, caller.uid);
+		assert.ok(typeof f.lastPingAt === 'number' && f.lastPingAt > 0, 'lastPingAt is a timestamp');
+
+		// persisted
+		assert.deepStrictEqual(topics._storedFollowups[tid], f);
+
+		// socket emitted
+		assert.strictEqual(emitted.length >= 1, true);
+		assert.strictEqual(emitted[0].event, 'event:followup:requested');
+
+		// event logged
+		assert.strictEqual(logged.length >= 1, true);
+		assert.strictEqual(logged[0].type, 'followup-request');
+		assert.strictEqual(logged[0].tid, tid);
+	});
+
+	it('resolveFollowup: sets pending=false and clears requester; emits and logs', async () => {
+		const caller = { uid: 9, ip: '5.6.7.8' };
+		const tid = 99;
+
+		// seed an existing followup to ensure update path
+		topics._storedFollowups[tid] = { pending: true, requestedBy: 777, lastPingAt: Date.now() - 1000 };
+
+		const res = await topicsApi.resolveFollowup(caller, { tid });
+		const f = res.followup;
+
+		assert.strictEqual(f.pending, false);
+		assert.strictEqual(f.requestedBy, 0);
+		assert.strictEqual(f.lastPingAt, 0);
+
+		// persisted
+		assert.deepStrictEqual(topics._storedFollowups[tid], f);
+
+		// socket emitted
+		assert.strictEqual(emitted.length >= 1, true);
+		assert.strictEqual(emitted[0].event, 'event:followup:resolved');
+
+		// event logged
+		assert.strictEqual(logged.length >= 1, true);
+		assert.strictEqual(logged[0].type, 'followup-resolve');
+		assert.strictEqual(logged[0].tid, tid);
+	});
+
+	it('requestFollowup: throws when missing privilege (403-like)', async () => {
+		const caller = { uid: 5, ip: '1.1.1.1' };
+		const tid = 7;
+
+		followupGuard.assertCanRequestFollowup = async () => {
+			throw new Error('[[error:no-followup-privileges]]');
+		};
+
+		await assert.rejects(
+			async () => topicsApi.requestFollowup(caller, { tid }),
+			err => /no-followup-privileges/.test(err.message)
+		);
+	});
+
+	it('requestFollowup: throws on cooldown breach (429-like)', async () => {
+		const caller = { uid: 6, ip: '2.2.2.2' };
+		const tid = 8;
+
+		followupGuard.assertCooldownAndMark = async () => {
+			throw new Error('[[error:followup-cooldown]]');
+		};
+
+		await assert.rejects(
+			async () => topicsApi.requestFollowup(caller, { tid }),
+			err => /followup-cooldown/.test(err.message)
+		);
+	});
+
+	it('resolveFollowup: throws when missing resolve privilege (403-like)', async () => {
+		const caller = { uid: 11, ip: '3.3.3.3' };
+		const tid = 13;
+
+		followupGuard.assertCanResolveFollowup = async () => {
+			throw new Error('[[error:no-resolve-followup-privileges]]');
+		};
+
+		await assert.rejects(
+			async () => topicsApi.resolveFollowup(caller, { tid }),
+			err => /no-resolve-followup-privileges/.test(err.message)
+		);
+	});
+});

--- a/test/topics-followup-contract.test.js
+++ b/test/topics-followup-contract.test.js
@@ -1,0 +1,124 @@
+const assert = require('assert');
+
+function replace(obj, key, fn, originals) {
+	originals.push({ obj, key, orig: obj[key] });
+	obj[key] = fn;
+}
+
+function restoreAll(originals) {
+	for (const { obj, key, orig } of originals) {
+		obj[key] = orig;
+	}
+}
+
+describe('followup request contract (no extra deps)', () => {
+	let topicsAPI;
+	let topicsModule, guardModule, socketHelpers, pluginsModule, eventsModule;
+	let originals;
+
+	beforeEach(function () {
+		originals = [];
+		topicsModule = require('../src/topics');
+		guardModule = require('../src/topics/followup-guard');
+		socketHelpers = require('../src/socket.io/helpers');
+		pluginsModule = require('../src/plugins');
+		eventsModule = require('../src/events');
+
+		// stub topics methods
+		replace(topicsModule, 'exists', async () => true, originals);
+		replace(topicsModule, 'getTopicFields', async () => ({ tid: 1, title: 'T' }), originals);
+		const setFollowupCalls = [];
+		replace(topicsModule, 'setFollowup', async (tid, followup) => { setFollowupCalls.push({ tid, followup }); }, originals);
+		replace(topicsModule, 'getFollowup', async () => ({ pending: true, requestedBy: 42, lastPingAt: Date.now() }), originals);
+
+		// topic events.log
+		const topicEvents = topicsModule.events || {};
+		replace(topicsModule, 'events', { log: async () => {} }, originals);
+
+		// guard
+		replace(guardModule, 'assertCanRequestFollowup', async () => {}, originals);
+		replace(guardModule, 'assertCooldownAndMark', async () => {}, originals);
+
+		// sockets/plugins/events
+		const emitCalls = [];
+		replace(socketHelpers, 'emitToUids', async (event, payload, uids) => { emitCalls.push({ event, payload, uids }); }, originals);
+		const hookCalls = [];
+		replace(pluginsModule.hooks, 'fire', async (name, data) => { hookCalls.push({ name, data }); }, originals);
+		const eventsCalls = [];
+		replace(eventsModule, 'log', async (data) => { eventsCalls.push(data); }, originals);
+
+		// require API after stubs (fresh require)
+		delete require.cache[require.resolve('../src/api/topics')];
+		topicsAPI = require('../src/api/topics');
+
+		// attach helper refs to this scope for assertions
+		this._setFollowupCalls = setFollowupCalls;
+		this._emitCalls = emitCalls;
+		this._hookCalls = hookCalls;
+		this._eventsCalls = eventsCalls;
+	});
+
+	afterEach(function () {
+		restoreAll(originals);
+		delete require.cache[require.resolve('../src/api/topics')];
+	});
+
+	it('persists followup, emits socket event and fires hook', async function () {
+		const caller = { uid: 42, ip: '127.0.0.1' };
+		const res = await topicsAPI.requestFollowup(caller, { tid: 1 });
+
+		// return shape
+		assert(res && res.followup, 'expected followup in response');
+		assert.strictEqual(res.followup.pending, true);
+		assert.strictEqual(res.followup.requestedBy, 42);
+
+		// persistence called
+		assert(this._setFollowupCalls.length === 1, 'setFollowup should be called once');
+
+		// socket emitted
+		assert(this._emitCalls.length === 1, 'socket emit should be called once');
+		assert(/event:followup:requested/.test(this._emitCalls[0].event));
+		assert.strictEqual(this._emitCalls[0].payload.tid, 1);
+
+		// hook fired
+		assert(this._hookCalls.length === 1, 'hook fire should be called once');
+		assert.strictEqual(this._hookCalls[0].name, 'action:followup.requested');
+	});
+});
+
+describe('followup missing topic (no extra deps)', () => {
+	let topicsAPI;
+	let topicsModule, guardModule;
+	let originals;
+
+	beforeEach(function () {
+		originals = [];
+		topicsModule = require('../src/topics');
+		guardModule = require('../src/topics/followup-guard');
+
+		replace(topicsModule, 'exists', async () => false, originals);
+		replace(guardModule, 'assertCanRequestFollowup', async () => {}, originals);
+		replace(guardModule, 'assertCooldownAndMark', async () => {}, originals);
+
+		delete require.cache[require.resolve('../src/api/topics')];
+		topicsAPI = require('../src/api/topics');
+	});
+
+	afterEach(function () {
+		restoreAll(originals);
+		delete require.cache[require.resolve('../src/api/topics')];
+	});
+
+	it('throws 404 with .status set', async () => {
+		const caller = { uid: 10 };
+		let threw = false;
+		try {
+			await topicsAPI.requestFollowup(caller, { tid: 9999 });
+		} catch (err) {
+			threw = true;
+			assert(err instanceof Error, 'expected an Error');
+			assert.strictEqual(err.status, 404, 'expected status 404');
+		}
+		assert(threw, 'expected function to throw');
+	});
+});


### PR DESCRIPTION
This should solve this issue: https://github.com/orgs/CMU-313/projects/280/views/1?pane=issue&itemId=128738925&issue=CMU-313%7Cnodebb-fall-2025-yonko%7C20

This should allow an endpoint to be visible for things like notification and ui changes