### PR TITLE
Backend hookup with UI to allow admins to view unanswered posts

### DIFF
--- a/public/src/modules/sort.js
+++ b/public/src/modules/sort.js
@@ -15,15 +15,6 @@ define('sort', ['components'], function (components) {
 			.off('click', '[component="thread/sort"] a[data-sort]')
 			.on('click', '[component="thread/sort"] a[data-sort]', function () {
 				const newSetting = $(this).attr('data-sort');
-				// If the new 'No Replies' sort option is selected, keep this front-end-only
-				// and just log the action to the console as requested. Real filtering or
-				// server-side changes are out of scope for this change.
-				if (newSetting === 'no_replies') {
-					console.log('No Replies selected');
-					// Close dropdown if applicable and prevent navigation
-					$(this).closest('.dropdown-menu').prev('[data-bs-toggle="dropdown"]').dropdown && $(this).closest('.dropdown-menu').prev('[data-bs-toggle="dropdown"]').dropdown('hide');
-					return false;
-				}
 				const urlParams = utils.params();
 				urlParams.sort = newSetting;
 				const qs = $.param(urlParams);

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -23,6 +23,9 @@ const url = nconf.get('url');
 const relative_path = nconf.get('relative_path');
 const validSorts = [
 	'recently_replied', 'recently_created', 'most_posts', 'most_votes', 'most_views',
+	// Allow server-side rendering to accept the 'no_replies' sort so the initial
+	// category page respects the frontend 'No Replies' selection.
+	'no_replies',
 ];
 
 categoryController.get = async function (req, res, next) {
@@ -149,7 +152,14 @@ categoryController.get = async function (req, res, next) {
 	categoryData.topicIndex = topicIndex;
 	categoryData.selectedTag = tagData.selectedTag;
 	categoryData.selectedTags = tagData.selectedTags;
-	categoryData.sortOptionLabel = `[[topic:${validator.escape(String(sort)).replace(/_/g, '-')}]]`;
+	// For the 'no_replies' sort we don't yet have a translation key in all
+	// language bundles in this workspace, so set a human-friendly label here
+	// to avoid showing the raw sort key in the UI.
+	if (sort === 'no_replies') {
+		categoryData.sortOptionLabel = 'No Replies';
+	} else {
+		categoryData.sortOptionLabel = `[[topic:${validator.escape(String(sort)).replace(/_/g, '-')}]]`;
+	}
 
 	if (!meta.config['feeds:disableRSS']) {
 		categoryData.rssFeedUrl = `${url}/category/${categoryData.cid}.rss`;

--- a/src/views/partials/category/sort.tpl
+++ b/src/views/partials/category/sort.tpl
@@ -12,10 +12,12 @@
 			</a>
 		</li>
 			<li>
+				{{{ if privileges.isAdminOrMod }}}
 				<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" href="#" data-sort="no_replies" role="menuitem">
 					<span class="flex-grow-1">No Replies</span>
 					<i class="flex-shrink-0 fa fa-fw text-secondary"></i>
 				</a>
+				{{{ end }}}
 			</li>
 
 		<li>


### PR DESCRIPTION
### Reason for changes

Currently, as a professor there is no easy way to look at all unanswered questions all in the same place.

This issue focuses on the front-end aspect of this user story.

### Issue solved #14 

### Changes

https://github.com/user-attachments/assets/dd68abc8-fbe8-475e-acfb-35ecaf9967d7

